### PR TITLE
Fix image loading for RV Effect

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,10 @@ function precomputeBlackPixelCounts() {
 
 function getEffectPercentAtLST(LST_decimal) {
     if (!imageLoaded) {
-        loadEffectImage(true);
+        loadEffectImage();
+        if (!imageLoaded) {
+            return 0;
+        }
     }
 
     const imgWidth = canvas.width;


### PR DESCRIPTION
## Summary
- ensure `getEffectPercentAtLST` loads the image with `loadEffectImage()`
- bail out early if the effect image isn't ready

## Testing
- `git status --short`